### PR TITLE
Consolidate dependencies so all target frameworks only use the minimum required dependencies to function

### DIFF
--- a/Simple.HttpClientFactory.Tests/Simple.HttpClientFactory.Tests.csproj
+++ b/Simple.HttpClientFactory.Tests/Simple.HttpClientFactory.Tests.csproj
@@ -4,31 +4,40 @@
     <UserSecretsId>b7cd72c5-d465-41ff-bd0a-fcd61802b52f</UserSecretsId>
     <ProjectGuid>{1D95973D-CEE1-4F31-9E39-D8E22B4EB602}</ProjectGuid>
   </PropertyGroup>
+
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>netcoreapp5.0;net472</TargetFrameworks>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Flurl" Version="2.8.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="WireMock.Net" Version="1.2.7" />
+    <PackageReference Include="Flurl" Version="3.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="WireMock.Net" Version="1.3.7" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.2.1">
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Net.Security" Version="4.3.2" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Simple.HttpClientFactory\Simple.HttpClientFactory.csproj" />
   </ItemGroup>
+
 </Project>

--- a/Simple.HttpClientFactory/Simple.HttpClientFactory.csproj
+++ b/Simple.HttpClientFactory/Simple.HttpClientFactory.csproj
@@ -11,27 +11,15 @@
     <RepositoryUrl>https://github.com/myarichuk/Simple.HttpClientFactory</RepositoryUrl>
     <RepositoryType>Github</RepositoryType>
     <ProjectGuid>{709E1EB5-F770-4569-B08A-7867035217F3}</ProjectGuid>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='netstandard2.0|AnyCPU'">
     <CodeAnalysisRuleSet>Simple.HttpClientFactory.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)|$(Platform)'=='netcoreapp2.1|AnyCPU'">
-    <CodeAnalysisRuleSet>Simple.HttpClientFactory.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)|$(Platform)'=='netstandard2.0|AnyCPU'">    
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
-    <PackageReference Include="Polly" Version="7.2.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
+  <ItemGroup>
+    <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)|$(Platform)'=='netcoreapp2.1|AnyCPU'">
-    <PackageReference Include="Polly" Version="7.2.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Net.Security" Version="4.3.2" />
+  <ItemGroup Condition="'$(TargetFramework)|$(Platform)'=='netstandard2.0|AnyCPU'">
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The dependencies used by the main library as well as its test project can be streamlined so each project only uses the dependencies that are necessary to fulfil the needs of the framework currently being targeted.

This will avoid having to install redundant dependencies when a user's project targets a more recent .NET Core version or .NET 5.0.

![image](https://user-images.githubusercontent.com/1554615/100547727-93a53f00-3268-11eb-9480-4994e45f7614.png)
