### PR TITLE
Use the HttpStatusCode enum instead of magic numbers in unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ public HttpClient CreateClient() =>
     HttpClientFactory.Create()
                      .WithCertificate(DefaultDevCert.Get())         // configure with one or more X509Certificate2 instances
                      .WithPolicy(Policy<HttpResponseMessage>.Handle<HttpRequestException>()
-                                                            .OrResult(result => (int)result.StatusCode >= 500 || result.StatusCode == HttpStatusCode.RequestTimeout)
+                                                            .OrResult(result => result.StatusCode >= HttpStatusCode.InternalServerError || result.StatusCode == HttpStatusCode.RequestTimeout)
                                                             .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(1)))
                      .Build();
 

--- a/Simple.HttpClientFactory.Tests/BasicClientBuilderTests.cs
+++ b/Simple.HttpClientFactory.Tests/BasicClientBuilderTests.cs
@@ -27,7 +27,7 @@ namespace Simple.HttpClientFactory.Tests
             _server.Given(Request.Create().WithPath(_endpointUri).UsingAnyMethod())
                    .RespondWith(
                        Response.Create()
-                          .WithStatusCode(200)
+                          .WithStatusCode(HttpStatusCode.OK)
                           .WithHeader("Content-Type", "text/plain")
                           .WithBody("Hello world!"));
         }

--- a/Simple.HttpClientFactory.Tests/ExceptionTranslatorTests.cs
+++ b/Simple.HttpClientFactory.Tests/ExceptionTranslatorTests.cs
@@ -29,7 +29,7 @@ namespace Simple.HttpClientFactory.Tests
             _server.Given(Request.Create().WithPath(_endpointUri).UsingAnyMethod())
                 .RespondWith(
                     Response.Create()
-                        .WithStatusCode(200)
+                        .WithStatusCode(HttpStatusCode.OK)
                         .WithHeader("Content-Type", "text/plain")
                         .WithBody("Hello world!"));       
             
@@ -38,7 +38,7 @@ namespace Simple.HttpClientFactory.Tests
                     .WithPath(_endpointUriTimeout)
                     .UsingGet())
                 .RespondWith(Response.Create()
-                    .WithStatusCode(408));
+                    .WithStatusCode(HttpStatusCode.RequestTimeout));
         }
 
         public class TestException : Exception
@@ -85,7 +85,7 @@ namespace Simple.HttpClientFactory.Tests
                 .WithPolicy(
                     Policy<HttpResponseMessage>
                         .Handle<HttpRequestException>()
-                        .OrResult(result => (int)result.StatusCode >= 500 || result.StatusCode == HttpStatusCode.RequestTimeout)
+                        .OrResult(result => result.StatusCode >= HttpStatusCode.InternalServerError || result.StatusCode == HttpStatusCode.RequestTimeout)
                         .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(1)))
                 .WithPolicy(Policy.TimeoutAsync<HttpResponseMessage>(TimeSpan.FromSeconds(4), TimeoutStrategy.Optimistic))
                 .Build();
@@ -106,7 +106,7 @@ namespace Simple.HttpClientFactory.Tests
                 .WithPolicy(
                     Policy<HttpResponseMessage>
                         .Handle<HttpRequestException>()
-                        .OrResult(result => (int)result.StatusCode >= 500 || result.StatusCode == HttpStatusCode.RequestTimeout)
+                        .OrResult(result => result.StatusCode >= HttpStatusCode.InternalServerError || result.StatusCode == HttpStatusCode.RequestTimeout)
                         .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(1)))
                 .WithPolicy(Policy.TimeoutAsync<HttpResponseMessage>(TimeSpan.FromSeconds(4), TimeoutStrategy.Optimistic))
                 .Build();
@@ -146,7 +146,7 @@ namespace Simple.HttpClientFactory.Tests
                 .WithPolicy(
                     Policy<HttpResponseMessage>
                         .Handle<HttpRequestException>()
-                        .OrResult(result => (int)result.StatusCode >= 500 || result.StatusCode == HttpStatusCode.RequestTimeout)
+                        .OrResult(result => result.StatusCode >= HttpStatusCode.InternalServerError || result.StatusCode == HttpStatusCode.RequestTimeout)
                         .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(1)))
                 .WithPolicy(Policy.TimeoutAsync<HttpResponseMessage>(TimeSpan.FromSeconds(4), TimeoutStrategy.Optimistic))
                 .Build();
@@ -164,7 +164,7 @@ namespace Simple.HttpClientFactory.Tests
                 .WithPolicy(
                     Policy<HttpResponseMessage>
                         .Handle<HttpRequestException>()
-                        .OrResult(result => (int)result.StatusCode >= 500 || result.StatusCode == HttpStatusCode.RequestTimeout)
+                        .OrResult(result => result.StatusCode >= HttpStatusCode.InternalServerError || result.StatusCode == HttpStatusCode.RequestTimeout)
                         .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(1)))
                 .WithPolicy(Policy.TimeoutAsync<HttpResponseMessage>(TimeSpan.FromSeconds(4), TimeoutStrategy.Optimistic))
                 .Build();

--- a/Simple.HttpClientFactory.Tests/MiddlewareDelegateTests.cs
+++ b/Simple.HttpClientFactory.Tests/MiddlewareDelegateTests.cs
@@ -26,7 +26,7 @@ namespace Simple.HttpClientFactory.Tests
             _server.Given(Request.Create().WithPath(_endpointUri).UsingAnyMethod())
                    .RespondWith(
                        Response.Create()
-                          .WithStatusCode(200)
+                          .WithStatusCode(HttpStatusCode.OK)
                           .WithHeader("Content-Type", "text/plain")
                           .WithBody("Hello world!"));
         }

--- a/Simple.HttpClientFactory.Tests/SecureClientBuilderTests.cs
+++ b/Simple.HttpClientFactory.Tests/SecureClientBuilderTests.cs
@@ -25,7 +25,7 @@ namespace Simple.HttpClientFactory.Tests
             _server.Given(Request.Create().WithPath(_endpointUri).UsingAnyMethod())
                    .RespondWith(
                        Response.Create()
-                          .WithStatusCode(200)
+                          .WithStatusCode(HttpStatusCode.OK)
                           .WithHeader("Content-Type", "text/plain")
                           .WithBody("Hello world!"));
         }
@@ -37,7 +37,7 @@ namespace Simple.HttpClientFactory.Tests
                 .WithPolicy(
     					Policy<HttpResponseMessage>
                             .Handle<HttpRequestException>()
-                            .OrResult(result => (int)result.StatusCode >= 500 || result.StatusCode == HttpStatusCode.RequestTimeout)
+                            .OrResult(result => result.StatusCode >= HttpStatusCode.InternalServerError || result.StatusCode == HttpStatusCode.RequestTimeout)
                        .RetryAsync(3))
                 .Build();
 


### PR DESCRIPTION
Using literal (magic) numbers is generally advised against in programming and I think it'd be clearer if we switched over to the built-in `HttpStatusCode` enum instead.