### PR TITLE
Add .NET 5 targeting

### DIFF
--- a/Simple.HttpClientFactory.Tests/Simple.HttpClientFactory.Tests.csproj
+++ b/Simple.HttpClientFactory.Tests/Simple.HttpClientFactory.Tests.csproj
@@ -12,19 +12,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+    <Compile Remove="TestResults\**" />
+    <EmbeddedResource Remove="TestResults\**" />
+    <None Remove="TestResults\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="WireMock.Net" Version="1.3.9" />
+    <PackageReference Include="FakeItEasy" Version="7.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="WireMock.Net" Version="1.4.9" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Simple.HttpClientFactory/HttpClientBuilder.cs
+++ b/Simple.HttpClientFactory/HttpClientBuilder.cs
@@ -308,6 +308,20 @@ namespace Simple.HttpClientFactory
         private HttpClient CreateClientInternal<TPrimaryMessageHandler>(TPrimaryMessageHandler primaryMessageHandler, PollyMessageMiddleware rootPolicyHandler, DelegatingHandler lastMiddleware)
             where TPrimaryMessageHandler : HttpMessageHandler
         {
+            HttpClient createdClient;
+            if (rootPolicyHandler != null)
+                createdClient = InitializeClientWithPoliciesAndMiddleware();
+            else if (_middlewareHandlers.Count > 0)
+                createdClient = InitializeClientOnlyWithMiddleware();
+            else
+                createdClient = new HttpClient(primaryMessageHandler, true);
+
+            if (_baseUrl != null)
+                createdClient.BaseAddress = _baseUrl;
+
+            return createdClient;
+
+
             HttpClient InitializeClientWithPoliciesAndMiddleware()
             {
                 HttpClient client;
@@ -330,19 +344,6 @@ namespace Simple.HttpClientFactory
 
                 return client;
             }
-
-            HttpClient createdClient;
-            if (rootPolicyHandler != null)
-                createdClient = InitializeClientWithPoliciesAndMiddleware();
-            else if (_middlewareHandlers.Count > 0)
-                createdClient = InitializeClientOnlyWithMiddleware();
-            else
-                createdClient = new HttpClient(primaryMessageHandler, true);
-
-            if (_baseUrl != null)
-                createdClient.BaseAddress = _baseUrl;
-
-            return createdClient;
         }
     }
 }

--- a/Simple.HttpClientFactory/IHttpClientBuilder.cs
+++ b/Simple.HttpClientFactory/IHttpClientBuilder.cs
@@ -80,7 +80,7 @@ namespace Simple.HttpClientFactory
         /// <remarks>This adds a call to <see cref="HttpResponseMessage.EnsureSuccessStatusCode"/>, thus ensuring that <see cref="HttpRequestException"/> will get thrown on a non-success response.</remarks>
         IHttpClientBuilder WithMessageExceptionHandler(Func<HttpRequestException, bool> exceptionHandlingPredicate, Func<HttpRequestException, Exception> exceptionHandler, EventHandler<HttpRequestException> requestExceptionEventHandler = null, EventHandler<Exception> transformedRequestExceptionEventHandler = null);
 
-#if NETCOREAPP2_1
+#if NETCOREAPP2_1_OR_GREATER
         /// <summary>
         /// Configures the primary message handler before the client is instantiated.
         /// </summary>

--- a/Simple.HttpClientFactory/MessageHandlers/HttpClientHandlerEx.cs
+++ b/Simple.HttpClientFactory/MessageHandlers/HttpClientHandlerEx.cs
@@ -89,14 +89,14 @@ namespace Simple.HttpClientFactory.MessageHandlers
             public override int GetHashCode() => HashCode.Combine(_uri.Scheme, _uri.DnsSafeHost, _uri.Port);
 
             /// <summary>
-            /// Determines whether two specified <see cref="UriCacheKey"></see> object are considered to be the same.
+            /// Determines whether two specified <see cref="UriCacheKey"></see> objects are considered to be the same.
             /// </summary>
             /// <param name="left">The first <see cref="UriCacheKey"></see> object to compare.</param>
             /// <param name="right">The second <see cref="UriCacheKey"></see> object to compare.</param>
             public static bool operator ==(UriCacheKey left, UriCacheKey right) => left.Equals(right);
 
             /// <summary>
-            /// Determines whether two specified <see cref="UriCacheKey"></see> object are considered to be different.
+            /// Determines whether two specified <see cref="UriCacheKey"></see> objects are considered to be different.
             /// </summary>
             /// <param name="left">The first <see cref="UriCacheKey"></see> object to compare.</param>
             /// <param name="right">The second <see cref="UriCacheKey"></see> object to compare.</param>

--- a/Simple.HttpClientFactory/Simple.HttpClientFactory.csproj
+++ b/Simple.HttpClientFactory/Simple.HttpClientFactory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;net5.0</TargetFrameworks>
     <Authors>Michael Yarichuk</Authors>
     <Company>Michael Yarichuk</Company>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)|$(Platform)'=='netstandard2.0|AnyCPU'">
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET Core 2.1 is going end-of-life in August 2021. 

To keep the library up-do-date, I've added .NET 5  targeting in parallell with the already existing .NET Core 2.1 and .NET Standard 2.0 TFMs.